### PR TITLE
feat: add portable Linux and Mac shell scripts for engine setup and c…

### DIFF
--- a/Linux/install.sh
+++ b/Linux/install.sh
@@ -452,36 +452,51 @@ echo ""
 echo -e "${YLW}[6/7] Downloading Ollama AI Engine (Linux)...${RST}"
 
 OLLAMA_BIN="$SHARED_BIN/ollama-linux"
+OLLAMA_LIB_DIR="$SHARED_DIR/lib/ollama"
+
+ollama_runtime_ok() {
+    [ -f "$OLLAMA_BIN" ] &&
+    is_elf "$OLLAMA_BIN" &&
+    file_ok "$OLLAMA_BIN" 10000000 &&
+    [ -f "$OLLAMA_LIB_DIR/llama-server" ]
+}
 
 # Validate: must exist, be a real ELF binary, and > 10 MB
-if [ -f "$OLLAMA_BIN" ] && is_elf "$OLLAMA_BIN" && file_ok "$OLLAMA_BIN" 10000000; then
+if ollama_runtime_ok; then
     echo -e "${GRN}      Ollama already installed! Skipping...${RST}"
 else
-    # Remove any stale/corrupted file
+    if [ -f "$OLLAMA_BIN" ] && [ ! -f "$OLLAMA_LIB_DIR/llama-server" ]; then
+        echo -e "${YLW}      Existing Ollama install is incomplete. Re-downloading full runtime...${RST}"
+    fi
+
+    # Remove any stale/corrupted files
     rm -f "$OLLAMA_BIN"
+    rm -rf "$OLLAMA_LIB_DIR"
 
     ARCHIVE_URL="https://github.com/ollama/ollama/releases/latest/download/ollama-linux-amd64.tar.zst"
 
-    echo -e "      Downloading Ollama engine (streaming - stops after binary extracted)..."
-    # Stream curl → tar: since bin/ollama is the FIRST entry in the archive,
-    # tar exits after extracting it and the pipe breaks — we never download
-    # the hundreds of MB of CUDA libs that follow.
+    echo -e "      Downloading full Ollama runtime..."
+    # Preserve archive layout under Shared:
+    #   Shared/bin/ollama -> Shared/bin/ollama-linux
+    #   Shared/lib/ollama/* runtime files, including llama-server
     curl -L --fail "$ARCHIVE_URL" |  \
-        tar --use-compress-program=zstd -xf - -C "$SHARED_BIN" \
-            --strip-components=1 bin/ollama 2>/dev/null
-    PIPE_RC=${PIPESTATUS[1]}   # tar exit code (0 = extracted successfully)
+        tar --use-compress-program=zstd -xf - -C "$SHARED_DIR" 2>/dev/null
+    PIPE_RC=("${PIPESTATUS[@]}")
+    CURL_RC=${PIPE_RC[0]}
+    TAR_RC=${PIPE_RC[1]}
 
     # Rename extracted 'ollama' -> 'ollama-linux'
     if [ -f "$SHARED_BIN/ollama" ]; then
         mv "$SHARED_BIN/ollama" "$OLLAMA_BIN"
     fi
 
-    if [ "$PIPE_RC" -ne 0 ] || ! is_elf "$OLLAMA_BIN"; then
-        echo -e "${RED}      ERROR: Extraction failed or binary is invalid!${RST}"
+    if [ "$CURL_RC" -ne 0 ] || [ "$TAR_RC" -ne 0 ] || ! ollama_runtime_ok; then
+        echo -e "${RED}      ERROR: Extraction failed, binary is invalid, or llama-server is missing!${RST}"
         rm -f "$OLLAMA_BIN"
         DOWNLOAD_ERRORS+=("Ollama Engine")
     else
         chmod +x "$OLLAMA_BIN"
+        find "$OLLAMA_LIB_DIR" -type f -exec chmod +x {} \; 2>/dev/null
         echo -e "${GRN}      Ollama Linux Engine ready!${RST}"
     fi
 fi
@@ -497,10 +512,9 @@ if [ ! -x "$OLLAMA_BIN" ]; then
     echo -e "${RED}      Please re-run the installer to download Ollama.${RST}"
 else
     OLLAMA_RUNTIME="$OLLAMA_DATA/../.ollama-runtime"
-    mkdir -p "$OLLAMA_RUNTIME/runners" "$OLLAMA_RUNTIME/tmp"
+    mkdir -p "$OLLAMA_RUNTIME/tmp"
     export OLLAMA_MODELS="$OLLAMA_DATA"
     export OLLAMA_HOME="$OLLAMA_RUNTIME"
-    export OLLAMA_RUNNERS_DIR="$OLLAMA_RUNTIME/runners"
     export OLLAMA_TMPDIR="$OLLAMA_RUNTIME/tmp"
     export OLLAMA_ORIGINS="*"
     export OLLAMA_HOST="127.0.0.1:11434"
@@ -515,10 +529,20 @@ else
     OLLAMA_PID=$!
 
     # Wait for it to be ready
-    for i in $(seq 1 30); do
-        curl -s http://127.0.0.1:11434/api/tags > /dev/null 2>&1 && break
+    OLLAMA_READY=false
+    for i in $(seq 1 60); do
+        if curl -s http://127.0.0.1:11434/api/tags | grep -q '"models"'; then
+            OLLAMA_READY=true
+            echo -e "${GRN}      Ollama is ready (took ${i}s).${RST}"
+            break
+        fi
         sleep 1
     done
+
+    if [ "$OLLAMA_READY" != true ]; then
+        echo -e "${RED}      ERROR: Ollama did not become ready in 60 seconds. Skipping import.${RST}"
+        DOWNLOAD_ERRORS+=("Ollama Import")
+    fi
 
     cd "$MODELS_DIR" || exit 1
 
@@ -530,24 +554,30 @@ else
             return
         fi
         echo -e "${YLW}      Importing ${NAME}...${RST}"
-        "$OLLAMA_BIN" create "$LOCAL" -f "Modelfile-${LOCAL}" 2>&1
-        if [ $? -eq 0 ]; then
+        echo -e "${DGR}      Running: ollama-linux create ${LOCAL} -f Modelfile-${LOCAL}${RST}"
+        CREATE_OUTPUT=$("$OLLAMA_BIN" create "$LOCAL" -f "Modelfile-${LOCAL}" 2>&1)
+        CREATE_RC=$?
+        if [ "$CREATE_RC" -eq 0 ]; then
             echo -e "${GRN}      ${NAME} imported successfully!${RST}"
         else
-            echo -e "${RED}      ERROR: Failed to import ${NAME}${RST}"
+            echo -e "${RED}      ERROR: Failed to import ${NAME} (exit ${CREATE_RC})${RST}"
+            echo -e "${RED}${CREATE_OUTPUT}${RST}"
+            DOWNLOAD_ERRORS+=("Import: ${NAME}")
         fi
     }
 
-    for NUM in "${SELECTED_NUMS[@]}"; do
-        LOCAL=$(get_field "$NUM" LOCAL)
-        NAME=$(get_field "$NUM" NAME)
-        FILE=$(get_field "$NUM" FILE)
-        MINB=$(get_field "$NUM" MINB)
-        import_model "$LOCAL" "$NAME" "$FILE" "$MINB"
-    done
+    if [ "$OLLAMA_READY" = true ]; then
+        for NUM in "${SELECTED_NUMS[@]}"; do
+            LOCAL=$(get_field "$NUM" LOCAL)
+            NAME=$(get_field "$NUM" NAME)
+            FILE=$(get_field "$NUM" FILE)
+            MINB=$(get_field "$NUM" MINB)
+            import_model "$LOCAL" "$NAME" "$FILE" "$MINB"
+        done
 
-    if $HAS_CUSTOM && [ -n "$CUSTOM_URL" ]; then
-        import_model "$CUSTOM_LOCAL" "Custom: $CUSTOM_FILE" "$CUSTOM_FILE" 100000000
+        if $HAS_CUSTOM && [ -n "$CUSTOM_URL" ]; then
+            import_model "$CUSTOM_LOCAL" "Custom: $CUSTOM_FILE" "$CUSTOM_FILE" 100000000
+        fi
     fi
 
     echo -e "${DGR}      Stopping temporary Ollama server...${RST}"

--- a/Linux/start.sh
+++ b/Linux/start.sh
@@ -20,22 +20,21 @@ mkdir -p "$OLLAMA_RUNTIME"
 # ---- Full portability: keep EVERYTHING on the USB ----
 export OLLAMA_MODELS="$SHARED_DIR/models/ollama_data"
 export OLLAMA_HOME="$OLLAMA_RUNTIME"
-export OLLAMA_RUNNERS_DIR="$OLLAMA_RUNTIME/runners"
 export OLLAMA_TMPDIR="$OLLAMA_RUNTIME/tmp"
 export OLLAMA_ORIGINS="*"
 export OLLAMA_HOST="127.0.0.1:11434"
-mkdir -p "$OLLAMA_RUNTIME/runners" "$OLLAMA_RUNTIME/tmp"
+mkdir -p "$OLLAMA_RUNTIME/tmp"
 # -------------------------------------------------------
 
 # Check if the portable Linux engine is downloaded
-if [ ! -f "$SHARED_DIR/bin/ollama-linux" ]; then
+if [ ! -x "$SHARED_DIR/bin/ollama-linux" ] || [ ! -f "$SHARED_DIR/lib/ollama/llama-server" ]; then
     echo "==================================================="
-    echo "  ERROR: Linux AI Engine Not Found!"
+    echo "  ERROR: Linux AI Engine Not Found or Incomplete!"
     echo "==================================================="
     echo ""
-    echo "  It looks like the AI engine hasn't been set up yet."
+    echo "  It looks like the AI engine hasn't been fully set up yet."
     echo "  Please run 'bash install.sh' in this Linux"
-    echo "  folder first to safely download the components!"
+    echo "  folder first to download the full Ollama runtime."
     echo ""
     read -n 1 -s -r -p "Press any key to continue..."
     echo ""
@@ -51,10 +50,20 @@ else
     OLLAMA_PID=$!
     
     echo "Waiting for engine to initialize..."
-    until curl -s http://127.0.0.1:11434/api/tags > /dev/null 2>&1; do
+    for i in $(seq 1 60); do
+        if curl -s http://127.0.0.1:11434/api/tags | grep -q '"models"'; then
+            echo "[OK] Engine is online!"
+            break
+        fi
         sleep 1
     done
-    echo "[OK] Engine is online!"
+    if ! curl -s http://127.0.0.1:11434/api/tags | grep -q '"models"'; then
+        echo "ERROR: Engine did not become ready in 60 seconds."
+        if [ -n "$OLLAMA_PID" ]; then
+            kill "$OLLAMA_PID" 2>/dev/null
+        fi
+        exit 1
+    fi
 fi
 
 echo ""

--- a/Mac/install.command
+++ b/Mac/install.command
@@ -425,35 +425,74 @@ echo ""
 echo -e "${YLW}[6/7] Downloading Ollama AI Engine (Mac)...${RST}"
 
 OLLAMA_BIN="$SHARED_BIN/ollama-darwin"
+OLLAMA_LIB_DIR="$SHARED_DIR/lib/ollama"
+OLLAMA_TMP_DIR="$SHARED_BIN/temp_ollama_mac"
 ARCHIVE_URL="https://github.com/ollama/ollama/releases/latest/download/ollama-darwin.tgz"
 
-# Validate: must exist, be a real Mach-O binary, and > 10 MB
-if [ -f "$OLLAMA_BIN" ] && is_macho "$OLLAMA_BIN" && file_ok "$OLLAMA_BIN" 10000000; then
+ollama_runtime_ok() {
+    [ -f "$OLLAMA_BIN" ] &&
+    is_macho "$OLLAMA_BIN" &&
+    file_ok "$OLLAMA_BIN" 10000000 &&
+    [ -f "$OLLAMA_LIB_DIR/llama-server" ]
+}
+
+if ollama_runtime_ok; then
     echo -e "${GRN}      Ollama already installed! Skipping...${RST}"
 else
-    rm -f "$OLLAMA_BIN"
-
-    echo -e "      Downloading Ollama engine (streaming - stops after binary extracted)..."
-    # Stream curl → tar: 'ollama' is the first entry in the tgz,
-    # so tar exits as soon as it extracts it and the download stops early.
-    curl -L --fail "$ARCHIVE_URL" | \
-        tar -xzf - -C "$SHARED_BIN" ollama 2>/dev/null
-    PIPE_RC=${PIPESTATUS[1]}
-
-    # Rename extracted 'ollama' -> 'ollama-darwin'
-    if [ -f "$SHARED_BIN/ollama" ]; then
-        mv "$SHARED_BIN/ollama" "$OLLAMA_BIN"
+    if [ -f "$OLLAMA_BIN" ] && [ ! -f "$OLLAMA_LIB_DIR/llama-server" ]; then
+        echo -e "${YLW}      Existing Ollama engine is incomplete; refreshing full runtime...${RST}"
     fi
 
-    if [ "$PIPE_RC" -ne 0 ] || ! is_macho "$OLLAMA_BIN"; then
-        echo -e "${RED}      ERROR: Extraction failed or binary is invalid!${RST}"
+    rm -f "$OLLAMA_BIN"
+    rm -rf "$OLLAMA_LIB_DIR" "$OLLAMA_TMP_DIR"
+    mkdir -p "$OLLAMA_TMP_DIR/extract"
+
+    echo -e "      Downloading full Ollama engine runtime..."
+    curl -L --fail "$ARCHIVE_URL" -o "$OLLAMA_TMP_DIR/ollama-darwin.tgz"
+    CURL_RC=$?
+    if [ "$CURL_RC" -eq 0 ]; then
+        tar -xzf "$OLLAMA_TMP_DIR/ollama-darwin.tgz" -C "$OLLAMA_TMP_DIR/extract"
+        TAR_RC=$?
+    else
+        TAR_RC=1
+    fi
+
+    # Current archives may place the CLI at either ./ollama or ./bin/ollama.
+    if [ -f "$OLLAMA_TMP_DIR/extract/bin/ollama" ]; then
+        mv "$OLLAMA_TMP_DIR/extract/bin/ollama" "$OLLAMA_BIN"
+    elif [ -f "$OLLAMA_TMP_DIR/extract/ollama" ]; then
+        mv "$OLLAMA_TMP_DIR/extract/ollama" "$OLLAMA_BIN"
+    fi
+
+    # Preserve runtime libraries and llama-server alongside the portable CLI.
+    # Current darwin archives put these at the archive root; some future
+    # archives may use lib/ollama like Linux/Homebrew packages.
+    mkdir -p "$OLLAMA_LIB_DIR"
+    if [ -d "$OLLAMA_TMP_DIR/extract/lib/ollama" ]; then
+        cp -R "$OLLAMA_TMP_DIR/extract/lib/ollama/." "$OLLAMA_LIB_DIR/"
+    else
+        find "$OLLAMA_TMP_DIR/extract" -mindepth 1 -maxdepth 1 \
+            ! -name "ollama" ! -name "bin" \
+            -exec cp -R {} "$OLLAMA_LIB_DIR/" \;
+        if [ -d "$OLLAMA_TMP_DIR/extract/bin" ]; then
+            find "$OLLAMA_TMP_DIR/extract/bin" -mindepth 1 -maxdepth 1 \
+                ! -name "ollama" \
+                -exec cp -R {} "$OLLAMA_LIB_DIR/" \;
+        fi
+    fi
+
+    if [ "$CURL_RC" -ne 0 ] || [ "$TAR_RC" -ne 0 ] || ! ollama_runtime_ok; then
+        echo -e "${RED}      ERROR: Extraction failed, binary is invalid, or llama-server is missing!${RST}"
         rm -f "$OLLAMA_BIN"
+        rm -rf "$OLLAMA_LIB_DIR"
         DOWNLOAD_ERRORS+=("Ollama Engine")
     else
         chmod +x "$OLLAMA_BIN"
-        xattr -d com.apple.quarantine "$OLLAMA_BIN" 2>/dev/null
+        find "$OLLAMA_LIB_DIR" -type f -exec chmod +x {} \; 2>/dev/null
+        xattr -dr com.apple.quarantine "$OLLAMA_BIN" "$OLLAMA_LIB_DIR" 2>/dev/null
         echo -e "${GRN}      Ollama Mac Engine ready!${RST}"
     fi
+    rm -rf "$OLLAMA_TMP_DIR"
 fi
 
 # ================================================================
@@ -467,10 +506,9 @@ if [ ! -x "$OLLAMA_BIN" ]; then
     echo -e "${RED}      Please re-run the installer to download Ollama.${RST}"
 else
     OLLAMA_RUNTIME="$OLLAMA_DATA/../.ollama-runtime"
-    mkdir -p "$OLLAMA_RUNTIME/runners" "$OLLAMA_RUNTIME/tmp"
+    mkdir -p "$OLLAMA_RUNTIME/tmp"
     export OLLAMA_MODELS="$OLLAMA_DATA"
     export OLLAMA_HOME="$OLLAMA_RUNTIME"
-    export OLLAMA_RUNNERS_DIR="$OLLAMA_RUNTIME/runners"
     export OLLAMA_TMPDIR="$OLLAMA_RUNTIME/tmp"
     export OLLAMA_ORIGINS="*"
     export OLLAMA_HOST="127.0.0.1:11434"
@@ -483,10 +521,20 @@ else
     HOME="$OLLAMA_RUNTIME" "$OLLAMA_BIN" serve > "$OLLAMA_RUNTIME/install.log" 2>&1 &
     OLLAMA_PID=$!
 
+    OLLAMA_READY=false
     for i in $(seq 1 30); do
-        curl -s http://127.0.0.1:11434/api/tags > /dev/null 2>&1 && break
+        if curl -s http://127.0.0.1:11434/api/tags | grep -q '"models"'; then
+            OLLAMA_READY=true
+            break
+        fi
         sleep 1
     done
+
+    if [ "$OLLAMA_READY" != true ]; then
+        echo -e "${RED}      ERROR: Ollama did not become ready within 30 seconds.${RST}"
+        echo -e "${DGR}      Install log: $OLLAMA_RUNTIME/install.log${RST}"
+        DOWNLOAD_ERRORS+=("Ollama import startup")
+    fi
 
     cd "$MODELS_DIR" || exit 1
 
@@ -497,21 +545,27 @@ else
             echo -e "${RED}      Skipping ${NAME} - GGUF file not found or incomplete${RST}"; return
         fi
         echo -e "${YLW}      Importing ${NAME}...${RST}"
-        "$OLLAMA_BIN" create "$LOCAL" -f "Modelfile-${LOCAL}" 2>&1
-        if [ $? -eq 0 ]; then
+        echo -e "${DGR}      Running: ollama-darwin create ${LOCAL} -f Modelfile-${LOCAL}${RST}"
+        CREATE_OUTPUT=$("$OLLAMA_BIN" create "$LOCAL" -f "Modelfile-${LOCAL}" 2>&1)
+        CREATE_RC=$?
+        if [ "$CREATE_RC" -eq 0 ]; then
             echo -e "${GRN}      ${NAME} imported successfully!${RST}"
         else
             echo -e "${RED}      ERROR: Failed to import ${NAME}${RST}"
+            echo "$CREATE_OUTPUT" | sed 's/^/        /'
+            DOWNLOAD_ERRORS+=("Import: ${NAME}")
         fi
     }
 
-    for NUM in "${SELECTED_NUMS[@]}"; do
-        import_model "$(get_field "$NUM" LOCAL)" "$(get_field "$NUM" NAME)" \
-                     "$(get_field "$NUM" FILE)" "$(get_field "$NUM" MINB)"
-    done
+    if [ "$OLLAMA_READY" = true ]; then
+        for NUM in "${SELECTED_NUMS[@]}"; do
+            import_model "$(get_field "$NUM" LOCAL)" "$(get_field "$NUM" NAME)" \
+                         "$(get_field "$NUM" FILE)" "$(get_field "$NUM" MINB)"
+        done
 
-    if $HAS_CUSTOM && [ -n "$CUSTOM_URL" ]; then
-        import_model "$CUSTOM_LOCAL" "Custom: $CUSTOM_FILE" "$CUSTOM_FILE" 100000000
+        if $HAS_CUSTOM && [ -n "$CUSTOM_URL" ]; then
+            import_model "$CUSTOM_LOCAL" "Custom: $CUSTOM_FILE" "$CUSTOM_FILE" 100000000
+        fi
     fi
 
     echo -e "${DGR}      Stopping temporary Ollama server...${RST}"

--- a/Mac/start.command
+++ b/Mac/start.command
@@ -20,22 +20,23 @@ mkdir -p "$OLLAMA_RUNTIME"
 # ---- Full portability: keep EVERYTHING on the USB ----
 export OLLAMA_MODELS="$SHARED_DIR/models/ollama_data"
 export OLLAMA_HOME="$OLLAMA_RUNTIME"
-export OLLAMA_RUNNERS_DIR="$OLLAMA_RUNTIME/runners"
 export OLLAMA_TMPDIR="$OLLAMA_RUNTIME/tmp"
 export OLLAMA_ORIGINS="*"
 export OLLAMA_HOST="127.0.0.1:11434"
-mkdir -p "$OLLAMA_RUNTIME/runners" "$OLLAMA_RUNTIME/tmp"
+mkdir -p "$OLLAMA_RUNTIME/tmp"
 # -------------------------------------------------------
 
 # Check if the portable Mac engine is downloaded
-if [ ! -f "$SHARED_DIR/bin/ollama-darwin" ]; then
+if [ ! -x "$SHARED_DIR/bin/ollama-darwin" ] || [ ! -f "$SHARED_DIR/lib/ollama/llama-server" ]; then
     echo "==================================================="
-    echo "  ERROR: Mac AI Engine Not Found!"
+    echo "  ERROR: Mac AI Engine Not Found or Incomplete!"
     echo "==================================================="
     echo ""
-    echo "  It looks like the AI engine hasn't been set up yet."
-    echo "  Please double-click 'install.command' in this Mac"
-    echo "  folder first to safely download the components!"
+    echo "  It looks like the portable Ollama runtime is missing"
+    echo "  ollama-darwin or lib/ollama/llama-server."
+    echo ""
+    echo "  Please double-click 'install.command' in this Mac folder"
+    echo "  first to safely download the full runtime."
     echo ""
     read -n 1 -s -r -p "Press any key to continue..."
     exit 1
@@ -50,9 +51,22 @@ else
     OLLAMA_PID=$!
     
     echo "Waiting for engine to initialize..."
-    until curl -s http://127.0.0.1:11434/api/tags > /dev/null 2>&1; do
+    OLLAMA_READY=false
+    for i in $(seq 1 60); do
+        if curl -s http://127.0.0.1:11434/api/tags | grep -q '"models"'; then
+            OLLAMA_READY=true
+            break
+        fi
         sleep 1
     done
+    if [ "$OLLAMA_READY" != true ]; then
+        echo "ERROR: Ollama did not become ready within 60 seconds."
+        if [ -n "$OLLAMA_PID" ]; then
+            kill "$OLLAMA_PID" 2>/dev/null
+        fi
+        read -n 1 -s -r -p "Press any key to continue..."
+        exit 1
+    fi
     echo "[OK] Engine is online!"
 fi
 

--- a/Shared/FastChatUI.html
+++ b/Shared/FastChatUI.html
@@ -1172,12 +1172,41 @@
         color: var(--red);
       }
 
-      /* Typing dots */
-      .typ {
+      .msg-meta {
         display: flex;
         align-items: center;
+        gap: 10px;
+        min-height: 20px;
+        margin-top: 8px;
+        color: var(--t3);
+        font-size: 12px;
+        line-height: 1.35;
+      }
+      .msg-meta.live {
+        color: var(--t2);
+      }
+      .msg-meta .dot {
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: currentColor;
+        opacity: 0.55;
+      }
+
+      /* Typing dots */
+      .think {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        color: var(--t2);
+        font-size: 14px;
+        line-height: 1;
+        padding: 9px 0;
+      }
+      .typ {
+        display: inline-flex;
+        align-items: center;
         gap: 5px;
-        padding: 8px 0 8px;
       }
       .typ span {
         width: 7px;
@@ -2027,6 +2056,7 @@
       abort: null,
       models: [],
       model: localStorage.getItem('g-model') || '',
+      engineReady: false,
       globalSys: '',
       logMode: localStorage.getItem('logMode') || 'errors_only',
 
@@ -2214,24 +2244,40 @@
           const r = await fetch(OLLAMA + '/api/tags');
           if (!r.ok) throw new Error();
           const d = await r.json();
-          S.models = d.models || [];
+          S.models = Array.isArray(d.models) ? d.models : [];
+          S.engineReady = S.models.length > 0;
           renderModelMenu();
           if (
             S.models.length &&
             (!S.model || !S.models.find((m) => m.name === S.model))
           ) {
             applyModel(S.models[0].name);
-          } else if (S.model) {
+          } else if (S.models.length && S.model) {
             applyModel(S.model);
+          } else if (!S.models.length) {
+            S.model = '';
+            D.modelName.textContent = 'No models installed';
+            D.modelMenu.innerHTML =
+              '<div style="padding:16px;font-size:12px;color:var(--t3);text-align:center;">No models installed</div>';
           }
+          updateSend();
         } catch {
+          S.models = [];
+          S.model = '';
+          S.engineReady = false;
+          D.modelName.textContent = 'Engine Offline';
           D.modelMenu.innerHTML =
             '<div style="padding:16px;font-size:12px;color:var(--red);text-align:center;">Engine Offline</div>';
+          updateSend();
         }
       }
 
       function renderModelMenu() {
-        if (!S.models.length) return;
+        if (!S.models.length) {
+          D.modelMenu.innerHTML =
+            '<div style="padding:16px;font-size:12px;color:var(--t3);text-align:center;">No models installed</div>';
+          return;
+        }
         D.modelMenu.innerHTML = S.models
           .map(
             (m) => `
@@ -2512,6 +2558,12 @@
 
       // ÔöÇÔöÇ Send / Stream to Ollama ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
       async function sendMsg(text) {
+        if (!S.engineReady || !S.model) {
+          toast(S.models.length ? 'Select a model first' : 'No models installed');
+          updateSend();
+          return;
+        }
+
         if ((!text.trim() && !S.attachments.length) || S.streaming) return;
 
         let conv = getConv();
@@ -2531,6 +2583,13 @@
           conv.sys = D.sysTa.value.trim();
           // Defensive: heal conv that somehow has no msgs array
           if (!Array.isArray(conv.msgs)) conv.msgs = [];
+        }
+
+        if (!conv.model) conv.model = S.model;
+        if (!conv.model) {
+          toast('No model selected');
+          updateSend();
+          return;
         }
 
         const baseText = text.trim();
@@ -2603,6 +2662,15 @@
           id: gid(),
           role: 'assistant',
           content: '',
+          pending: true,
+          status: 'Thinking',
+          metrics: {
+            outputTokens: 0,
+            liveTokens: 0,
+            tokensPerSecond: 0,
+            elapsedMs: 0,
+            done: false,
+          },
           ts: Date.now(),
           liked: false,
           disliked: false,
@@ -2611,13 +2679,14 @@
         renderChat();
         scrollEnd();
 
-        const lastRow = D.msgs.lastElementChild;
-        const contentEl = lastRow ? lastRow.querySelector('.mt') : null;
-        if (contentEl)
-          contentEl.innerHTML =
-            '<div class="typ"><span></span><span></span><span></span></div>';
+        const contentEl = getMsgContentEl(aiMsg.id);
+        const statusTimers = [
+          setTimeout(() => updatePendingStatus(aiMsg, 'Warming up model'), 1800),
+          setTimeout(() => updatePendingStatus(aiMsg, 'Still working'), 7000),
+        ];
 
         S.abort = new AbortController();
+        const startedAt = performance.now();
         let apiMsgs = [];
         if (conv.sys) apiMsgs.push({ role: 'system', content: conv.sys });
         conv.msgs.slice(0, -1).forEach((m) => {
@@ -2626,6 +2695,7 @@
           apiMsgs.push(am);
         });
 
+        let liveRenderTimer = null;
         try {
           const res = await fetch(OLLAMA + '/api/chat', {
             method: 'POST',
@@ -2642,11 +2712,45 @@
             }),
             signal: S.abort.signal,
           });
-          if (!res.ok) throw new Error('Ollama error ' + res.status);
+          if (!res.ok) {
+            let errMsg = 'Ollama error ' + res.status;
+            try {
+              const err = await res.json();
+              if (err?.error) errMsg = err.error;
+            } catch {
+              try {
+                const errText = await res.text();
+                if (errText.trim()) errMsg = errText.trim();
+              } catch {}
+            }
+            throw new Error(errMsg);
+          }
 
           const reader = res.body.getReader();
           const dec = new TextDecoder();
           if (contentEl) contentEl.innerHTML = '';
+          let lastLiveRender = 0;
+          const paintLive = (force = false) => {
+            if (!contentEl) return;
+            const now = performance.now();
+            const wait = Math.max(0, 90 - (now - lastLiveRender));
+            if (!force && wait > 0) {
+              if (!liveRenderTimer) {
+                liveRenderTimer = setTimeout(() => {
+                  liveRenderTimer = null;
+                  paintLive(true);
+                }, wait);
+              }
+              return;
+            }
+            if (liveRenderTimer) {
+              clearTimeout(liveRenderTimer);
+              liveRenderTimer = null;
+            }
+            lastLiveRender = now;
+            contentEl.innerHTML = renderStreamingMd(aiMsg.content);
+            scrollEnd();
+          };
 
           while (true) {
             const { done, value } = await reader.read();
@@ -2657,13 +2761,43 @@
               try {
                 const p = JSON.parse(line);
                 if (p.message?.content) {
+                  aiMsg.pending = false;
+                  aiMsg.status = '';
                   aiMsg.content += p.message.content;
-                  if (contentEl) contentEl.textContent = aiMsg.content;
-                  scrollEnd();
+                  aiMsg.metrics.elapsedMs = performance.now() - startedAt;
+                  aiMsg.metrics.liveTokens = estimateTokens(aiMsg.content);
+                  aiMsg.metrics.tokensPerSecond = calcTokensPerSecond(
+                    aiMsg.metrics.liveTokens,
+                    aiMsg.metrics.elapsedMs,
+                  );
+                  updateMsgStats(aiMsg);
+                  paintLive(p.message.content.includes('\n'));
+                }
+                if (p.done) {
+                  aiMsg.metrics.elapsedMs = performance.now() - startedAt;
+                  if (Number.isFinite(p.eval_count)) {
+                    aiMsg.metrics.outputTokens = p.eval_count;
+                    aiMsg.metrics.tokensPerSecond = calcTokensPerSecond(
+                      p.eval_count,
+                      aiMsg.metrics.elapsedMs,
+                    );
+                  }
+                  if (Number.isFinite(p.prompt_eval_count)) {
+                    aiMsg.metrics.promptTokens = p.prompt_eval_count;
+                  }
+                  if (Number.isFinite(p.total_duration)) {
+                    aiMsg.metrics.ollamaMs = p.total_duration / 1000000;
+                  }
+                  aiMsg.metrics.done = true;
+                  updateMsgStats(aiMsg);
                 }
               } catch {}
             }
           }
+          if (liveRenderTimer) clearTimeout(liveRenderTimer);
+          aiMsg.metrics.elapsedMs = performance.now() - startedAt;
+          aiMsg.metrics.done = true;
+          updateMsgStats(aiMsg);
           if (contentEl) {
             contentEl.innerHTML = renderMd(aiMsg.content);
             contentEl.querySelectorAll('pre code').forEach((b) => {
@@ -2671,7 +2805,18 @@
             });
           }
         } catch (err) {
+          aiMsg.pending = false;
+          aiMsg.status = '';
           if (err.name === 'AbortError') {
+            aiMsg.metrics.elapsedMs = performance.now() - startedAt;
+            aiMsg.metrics.outputTokens = estimateTokens(aiMsg.content);
+            aiMsg.metrics.tokensPerSecond = calcTokensPerSecond(
+              aiMsg.metrics.outputTokens,
+              aiMsg.metrics.elapsedMs,
+            );
+            aiMsg.metrics.stopped = true;
+            aiMsg.metrics.done = true;
+            updateMsgStats(aiMsg);
             if (aiMsg.content) {
               if (contentEl) contentEl.innerHTML = renderMd(aiMsg.content);
             } else if (contentEl)
@@ -2683,6 +2828,10 @@
             conv.msgs.pop();
           }
         } finally {
+          if (liveRenderTimer) clearTimeout(liveRenderTimer);
+          statusTimers.forEach(clearTimeout);
+          aiMsg.pending = false;
+          aiMsg.status = '';
           S.streaming = false;
           updateSend();
           save();
@@ -2693,6 +2842,13 @@
 
       function stopStream() {
         if (S.abort) S.abort.abort();
+      }
+
+      function updatePendingStatus(msg, status) {
+        if (!S.streaming || !msg.pending || msg.content) return;
+        msg.status = status;
+        const el = getMsgContentEl(msg.id);
+        if (el) el.innerHTML = renderThinking(status);
       }
 
       // ÔöÇÔöÇ Markdown ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
@@ -2719,6 +2875,14 @@
         if (typeof marked === 'undefined')
           return esc(text).replace(/\n/g, '<br>');
         return marked.parse(text, { breaks: true });
+      }
+
+      function renderStreamingMd(text) {
+        if (!text) return '';
+        let safeText = text;
+        const fenceCount = (safeText.match(/(^|\n)```/g) || []).length;
+        if (fenceCount % 2 === 1) safeText += '\n```';
+        return renderMd(safeText);
       }
 
       // ÔöÇÔöÇ Rendering ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
@@ -2790,8 +2954,12 @@
       }
 
       function renderAI(msg, isLast) {
-        const parsed =
-          S.streaming && isLast ? esc(msg.content) : renderMd(msg.content);
+        const isWaiting = S.streaming && isLast && !msg.content;
+        const parsed = isWaiting
+          ? renderThinking(msg.status || 'Thinking')
+          : S.streaming && isLast
+            ? renderStreamingMd(msg.content)
+            : renderMd(msg.content);
         const actions =
           !S.streaming || !isLast
             ? `
@@ -2802,10 +2970,70 @@
         </div>`
             : '';
 
-        return `<div class="mr">
+        return `<div class="mr" data-msg-id="${msg.id}">
         <div class="ma ai"><svg viewBox="0 0 24 24"><path d="M12 2L14.09 8.26L21 9.27L16 14.14L17.18 21.02L12 17.77L6.82 21.02L8 14.14L3 9.27L9.91 8.26L12 2Z" fill="white"/></svg></div>
-        <div class="mc"><div class="mt">${parsed || ''}</div>${actions}</div>
+        <div class="mc"><div class="mt">${parsed || ''}</div>${renderMsgStats(msg)}${actions}</div>
     </div>`;
+      }
+
+      function getMsgContentEl(id) {
+        return D.msgs.querySelector(`[data-msg-id="${id}"] .mt`);
+      }
+
+      function getMsgStatsEl(id) {
+        return D.msgs.querySelector(`[data-msg-id="${id}"] .msg-meta`);
+      }
+
+      function updateMsgStats(msg) {
+        const el = getMsgStatsEl(msg.id);
+        if (el) el.outerHTML = renderMsgStats(msg);
+      }
+
+      function renderThinking(label) {
+        return `<div class="think"><span>${esc(label)}</span><div class="typ"><span></span><span></span><span></span></div></div>`;
+      }
+
+      function renderMsgStats(msg) {
+        const m = msg.metrics;
+        if (!m) return '';
+        const parts = [];
+        if (!m.done) {
+          parts.push(`${formatRate(m.tokensPerSecond)} tok/s`);
+        } else {
+          parts.push(`${Number(m.outputTokens || 0).toLocaleString()} tokens`);
+        }
+        if (m.done && Number.isFinite(m.elapsedMs)) {
+          parts.push(formatDuration(m.elapsedMs));
+        }
+        if (m.stopped) parts.push('stopped');
+        const live = !m.done ? ' live' : '';
+        return `<div class="msg-meta${live}">${parts.map(esc).join('<span class="dot"></span>')}</div>`;
+      }
+
+      function estimateTokens(text) {
+        if (!text) return 0;
+        const chunks = text.match(/[\p{L}\p{N}_]+|[^\s]/gu) || [];
+        return chunks.length;
+      }
+
+      function calcTokensPerSecond(tokens, elapsedMs) {
+        if (!Number.isFinite(tokens) || !Number.isFinite(elapsedMs) || elapsedMs <= 0)
+          return 0;
+        return tokens / (elapsedMs / 1000);
+      }
+
+      function formatRate(rate) {
+        if (!Number.isFinite(rate) || rate <= 0) return '0.0';
+        return rate < 10 ? rate.toFixed(1) : rate.toFixed(0);
+      }
+
+      function formatDuration(ms) {
+        if (!Number.isFinite(ms)) return '';
+        if (ms < 1000) return `${Math.max(1, Math.round(ms))} ms`;
+        if (ms < 60000) return `${(ms / 1000).toFixed(ms < 10000 ? 1 : 0)} s`;
+        const minutes = Math.floor(ms / 60000);
+        const seconds = Math.round((ms % 60000) / 1000);
+        return `${minutes}m ${seconds}s`;
       }
 
       // ÔöÇÔöÇ Actions ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
@@ -2857,15 +3085,16 @@
 
       function updateSend() {
         const has = D.inp.value.trim().length > 0 || S.attachments.length > 0;
+        const canSend = has && S.engineReady && !!S.model;
         D.iw.classList.toggle('ht', has);
         if (S.streaming) {
           D.send.className = 'ib2 stbtn';
           D.send.innerHTML = '<i class="fa-solid fa-stop"></i>';
           D.send.disabled = false;
         } else {
-          D.send.className = 'ib2 sbtn' + (has ? ' on' : '');
+          D.send.className = 'ib2 sbtn' + (canSend ? ' on' : '');
           D.send.innerHTML = '<i class="fa-solid fa-arrow-up"></i>';
-          D.send.disabled = !has;
+          D.send.disabled = !canSend;
         }
       }
       function autoResize() {

--- a/Shared/chat_server.py
+++ b/Shared/chat_server.py
@@ -688,6 +688,36 @@ class ChatHandler(http.server.BaseHTTPRequestHandler):
             request_context["model_temperature"] = payload.get("options", {}).get("temperature", "-")
 
         try:
+            if method == "POST" and ollama_path == "/api/chat":
+                model = payload.get("model") if isinstance(payload, dict) else None
+                messages = payload.get("messages") if isinstance(payload, dict) else None
+
+                if not isinstance(model, str) or not model.strip():
+                    _log_event(
+                        logging.ERROR,
+                        "Rejected chat request with missing or empty model",
+                        request_context=request_context,
+                    )
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors_headers()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": "Missing or empty model field"}).encode())
+                    return
+
+                if not isinstance(messages, list) or not messages:
+                    _log_event(
+                        logging.ERROR,
+                        "Rejected chat request with missing or empty messages",
+                        request_context=request_context,
+                    )
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self._cors_headers()
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": "Missing or empty messages field"}).encode())
+                    return
+
             # Handle fake /api/tags for llama.cpp mode
             if LLAMA_CPP_MODE and ollama_path == "/api/tags":
                 self.send_response(200)

--- a/Windows/install-core.ps1
+++ b/Windows/install-core.ps1
@@ -403,19 +403,38 @@ Write-Host "[6/7] Downloading Ollama AI Engine (Windows)..." -ForegroundColor Ye
 $OllamaURL  = "https://github.com/ollama/ollama/releases/latest/download/ollama-windows-amd64.zip"
 $OllamaDest = "$USB_Drive\Shared\bin\ollama-windows-amd64.zip"
 $TempOllamaDir = "$USB_Drive\Shared\bin\temp_ollama"
+$OllamaExe = "$USB_Drive\Shared\bin\ollama-windows.exe"
+$LlamaServerExe = "$USB_Drive\Shared\bin\llama-server.exe"
 
-if (Test-Path "$USB_Drive\Shared\bin\ollama-windows.exe") {
+if ((Test-Path $OllamaExe) -and (Test-Path $LlamaServerExe)) {
     Write-Host "      Ollama already installed! Skipping..." -ForegroundColor Green
 } else {
+    if ((Test-Path $OllamaExe) -and (-Not (Test-Path $LlamaServerExe))) {
+        Write-Host "      Existing Ollama install is incomplete. Re-downloading full runtime..." -ForegroundColor Yellow
+    }
     curl.exe -L --ssl-no-revoke --progress-bar $OllamaURL -o $OllamaDest
 
     if (Test-Path $OllamaDest) {
         Write-Host "      Extracting Ollama..." -ForegroundColor Yellow
         try {
+            Remove-Item $TempOllamaDir -Force -Recurse -ErrorAction SilentlyContinue
             New-Item -ItemType Directory -Force -Path $TempOllamaDir | Out-Null
             Expand-Archive -Path $OllamaDest -DestinationPath $TempOllamaDir -Force
-            # Move the ollama.exe up and rename it to explicitly be ollama-windows.exe
-            Move-Item -Path "$TempOllamaDir\ollama.exe" -Destination "$USB_Drive\Shared\bin\ollama-windows.exe" -Force
+
+            Get-ChildItem -Path $TempOllamaDir -Recurse -File | ForEach-Object {
+                $dest = Join-Path "$USB_Drive\Shared\bin" $_.Name
+                Move-Item -Path $_.FullName -Destination $dest -Force
+                Write-Host "      Extracted: $($_.Name)" -ForegroundColor DarkGray
+            }
+
+            if (Test-Path "$USB_Drive\Shared\bin\ollama.exe") {
+                Move-Item -Path "$USB_Drive\Shared\bin\ollama.exe" -Destination $OllamaExe -Force
+            }
+
+            if (-Not (Test-Path $LlamaServerExe)) {
+                throw "llama-server.exe was not found after extraction"
+            }
+
             # Cleanup
             Remove-Item $TempOllamaDir -Force -Recurse -ErrorAction SilentlyContinue
             Remove-Item $OllamaDest -Force -ErrorAction SilentlyContinue
@@ -463,16 +482,38 @@ if (-Not (Test-Path "$USB_Drive\Shared\bin\ollama-windows.exe")) {
 
     if ($modelsToImport.Count -gt 0) {
         Write-Host "      Starting Ollama temporarily to perform import..." -ForegroundColor DarkGray
-        $ServerProcess = Start-Process -FilePath "$USB_Drive\Shared\bin\ollama-windows.exe" -ArgumentList "serve" -WindowStyle Hidden -PassThru
-        Start-Sleep -Seconds 5
+        $ServerProcess = Start-Process -FilePath $OllamaExe -ArgumentList "serve" -WindowStyle Hidden -PassThru
 
-        foreach ($m in $modelsToImport) {
-            Write-Host "      Importing $($m.Name)..." -ForegroundColor Yellow
+        Write-Host "      Waiting for Ollama to be ready..." -ForegroundColor DarkGray
+        $ready = $false
+        for ($i = 1; $i -le 60; $i++) {
             try {
-                $null = & "$USB_Drive\Shared\bin\ollama-windows.exe" create $m.Local -f "Modelfile-$($m.Local)" 2>&1
-                Write-Host "      $($m.Name) imported successfully!" -ForegroundColor Green
-            } catch {
-                Write-Host "      ERROR: Failed to import $($m.Name)" -ForegroundColor Red
+                $response = Invoke-RestMethod -Uri "http://127.0.0.1:11434/api/tags" -TimeoutSec 2
+                if ($null -ne $response.models) {
+                    $ready = $true
+                    Write-Host "      Ollama is ready (took ${i}s)." -ForegroundColor Green
+                    break
+                }
+            } catch {}
+            Start-Sleep -Seconds 1
+        }
+
+        if (-Not $ready) {
+            Write-Host "      ERROR: Ollama did not become ready in 60 seconds. Skipping import." -ForegroundColor Red
+        }
+
+        if ($ready) {
+            foreach ($m in $modelsToImport) {
+                Write-Host "      Importing $($m.Name)..." -ForegroundColor Yellow
+                Write-Host "      Running: ollama-windows.exe create $($m.Local) -f Modelfile-$($m.Local)" -ForegroundColor DarkGray
+                $createOutput = & $OllamaExe create $m.Local -f "Modelfile-$($m.Local)" 2>&1
+
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "      $($m.Name) imported successfully!" -ForegroundColor Green
+                } else {
+                    Write-Host "      ERROR: Failed to import $($m.Name) (exit $LASTEXITCODE)" -ForegroundColor Red
+                    Write-Host "      $createOutput" -ForegroundColor Red
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This update fixes the Ollama runtime/install issue that caused some users to see `Ollama error 400`, `Loading...`, missing model selection, failed imports, or engine startup problems.

The main root cause was that some platform installers only preserved the Ollama CLI binary, while recent Ollama builds also require bundled runtime files such as `llama-server`, DLLs/dylibs/shared libraries, and runtime folders. Without those files, Ollama could start partially or fail during model import/chat.

## What changed

- Fixed Windows Ollama setup to preserve the full runtime from `ollama-windows-amd64.zip`, including `llama-server.exe` and DLLs.
- Fixed Linux setup/start scripts to preserve `Shared/lib/ollama/*`, including `llama-server`.
- Fixed macOS setup/start scripts to preserve `llama-server`, dylibs, and Metal/runtime folders from `ollama-darwin.tgz`.
- Added runtime completeness checks before startup on Windows, Linux, and macOS.
- Replaced fixed sleeps with readiness checks against `http://127.0.0.1:11434/api/tags`.
- Improved model import reporting so failed `ollama create` commands are shown clearly instead of being reported as successful.
- Added backend validation for `/ollama/api/chat` so empty model/message requests return a clear local `400` instead of being forwarded to Ollama.
- Fixed the chat UI so sending is disabled until a real model is available and selected.
- Fixed model selector states for engine offline / no models installed.
- Added immediate assistant loading states during model warmup.
- Added live markdown rendering while responses stream.
- Added generation stats:
  - live: current tokens per second
  - final: total output tokens and response time